### PR TITLE
Output list in YAML compatible format

### DIFF
--- a/lib/secret_hub/commands/bulk.rb
+++ b/lib/secret_hub/commands/bulk.rb
@@ -38,6 +38,15 @@ module SecretHub
         say "!txtgrn!Saved #{config_file}"
       end
 
+      def list_command
+        config.each do |repo, keys|
+          say "!txtblu!#{repo}:"
+          github.secrets(repo).each do |secret|
+            say "- !txtpur!#{secret}"
+          end
+        end
+      end
+
       def save_command
         clean = args['--clean']
 
@@ -55,15 +64,6 @@ module SecretHub
         end
       end
 
-      def list_command
-        config.each do |repo, keys|
-          say "!txtblu!#{repo}"
-          github.secrets(repo).each do |secret|
-            say "!txtpur!#{secret}"
-          end
-        end
-      end
-    
     private
 
       def clean_repo(repo, keys)
@@ -96,10 +96,7 @@ module SecretHub
       def config
         raise ConfigurationError, "Config file not found #{config_flie}" unless File.exist? config_file
         result = YAML.load_file config_file
-        result.each do |key, value|
-          raise ConfigurationError, "Invalid repo #{key}" unless key.include? '/'
-          raise ConfigurationError, "Invalid keys for #{key} - must be an array" unless value.is_a? Array
-        end
+        result.transform_values { |v| v || [] }
       end
     end
   end

--- a/lib/secret_hub/commands/list.rb
+++ b/lib/secret_hub/commands/list.rb
@@ -12,9 +12,9 @@ module SecretHub
 
       def run
         repo = args['REPO']
-        say "!txtblu!#{repo}"
+        say "!txtblu!#{repo}:"
         github.secrets(repo).each do |secret|
-          say "!txtpur!#{secret}"
+          say "- !txtpur!#{secret}"
         end
       end
     end

--- a/spec/approvals/cli/bulk/list
+++ b/spec/approvals/cli/bulk/list
@@ -1,6 +1,6 @@
-user/repo
-PASSWORD
-SECRET
-user/another-repo
-PASSWORD
-SECRET
+user/repo:
+- PASSWORD
+- SECRET
+user/another-repo:
+- PASSWORD
+- SECRET

--- a/spec/approvals/cli/exception
+++ b/spec/approvals/cli/exception
@@ -1,3 +1,3 @@
 SecretHub::APIError
 [404] not found
-guido/python
+guido/python:

--- a/spec/approvals/cli/list/ok
+++ b/spec/approvals/cli/list/ok
@@ -1,3 +1,3 @@
-matz/ruby
-PASSWORD
-SECRET
+matz/ruby:
+- PASSWORD
+- SECRET

--- a/spec/spec_mixin.rb
+++ b/spec/spec_mixin.rb
@@ -1,5 +1,5 @@
 module SpecMixin
   def reset_tmp_dir
-    system "cp spec/fixtures/secrets.yml tmp/secrets.yml"
+    system "cp spec/fixtures/*.yml tmp/"
   end
 end


### PR DESCRIPTION
- Change `secrethub bulk list` to output the list in YAML format
- Allow empty secrets array in the config file

These two features combined, allow us to quickly set up a configuration file by:

1.  Creating a YAML with only the repos we care about:

```yaml
# teno,yml
me/my-repo:
me/my-other-repo:
```

2. Generating the final YAML including the secrets:

```shell
$ secrethub bulk list temp.yml > secrethub.yml
```
