### PR TITLE
Tolerate missing secrets

### DIFF
--- a/lib/secret_hub/commands/bulk.rb
+++ b/lib/secret_hub/commands/bulk.rb
@@ -40,17 +40,10 @@ module SecretHub
       end
 
       def show_command
-        visible = args['--visible']
-
         config.each do |repo, secrets|
           say "!txtblu!#{repo}:"
           secrets.each do |key, value|
-            if value
-              value = value.obfuscate unless visible
-              say "  !txtpur!#{key}: !txtcyn!#{value}"
-            else
-              say "  !txtpur!#{key}: !txtred!*MISSING*"
-            end
+            show_secret key, value, args['--visible']
           end
         end
       end
@@ -112,6 +105,15 @@ module SecretHub
         end
 
         skipped
+      end
+
+      def show_secret(key, value, visible)
+        if value
+          value = value.obfuscate unless visible
+          say "  !txtpur!#{key}: !txtcyn!#{value}"
+        else
+          say "  !txtpur!#{key}: !txtred!*MISSING*"
+        end
       end
 
       def config_file

--- a/lib/secret_hub/config.rb
+++ b/lib/secret_hub/config.rb
@@ -40,15 +40,10 @@ module SecretHub
       secrets = [] unless secrets
       
       if secrets.is_a? Hash
-        secrets.map { |key, value| [key, value || value_from_env(key)] }.to_h
+        secrets.map { |key, value| [key, value || ENV[key]] }.to_h
       elsif secrets.is_a? Array
-        secrets.map { |key| [key, value_from_env(key)] }.to_h
+        secrets.map { |key| [key, ENV[key]] }.to_h
       end
-
-    end
-
-    def value_from_env(key)
-      ENV[key] || raise(MissingSecretError, "Please set the #{key} environment variable")
     end
   end
 end

--- a/lib/secret_hub/exceptions.rb
+++ b/lib/secret_hub/exceptions.rb
@@ -1,7 +1,6 @@
 module SecretHub
   SecretHubError = Class.new StandardError
   ConfigurationError = Class.new SecretHubError
-  MissingSecretError = Class.new SecretHubError
   
   class APIError < SecretHubError
     attr_reader :response

--- a/spec/approvals/cli/bulk/save
+++ b/spec/approvals/cli/bulk/save
@@ -9,4 +9,6 @@ user/array-repo
 save    SECRET_KEY  
 OK
 save    SECRET_ID  
-OK
+MISSING
+
+Skipped 1 missing secrets

--- a/spec/approvals/cli/bulk/save-clean
+++ b/spec/approvals/cli/bulk/save-clean
@@ -9,8 +9,10 @@ user/array-repo
 save    SECRET_KEY  
 OK
 save    SECRET_ID  
-OK
+MISSING
 delete  PASSWORD  
 OK
 delete  SECRET  
 OK
+
+Skipped 1 missing secrets

--- a/spec/approvals/cli/bulk/show
+++ b/spec/approvals/cli/bulk/show
@@ -4,4 +4,4 @@ user/repo:
   SECRET_KEY: ******************m-54mp13-k3y
 user/array-repo:
   SECRET_KEY: ******************m-54mp13-k3y
-  SECRET_ID: ****
+  SECRET_ID: *MISSING*

--- a/spec/approvals/cli/bulk/show-visible
+++ b/spec/approvals/cli/bulk/show-visible
@@ -4,4 +4,4 @@ user/repo:
   SECRET_KEY: 7h15-15-50m3-24nd0m-54mp13-k3y
 user/array-repo:
   SECRET_KEY: 7h15-15-50m3-24nd0m-54mp13-k3y
-  SECRET_ID: n00b
+  SECRET_ID: *MISSING*

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,7 +30,6 @@ ENV['GITHUB_ACCESS_TOKEN'] = 'who took my token?'
 ENV['SECRET'] = 'there is no spoon'
 ENV['PASSWORD'] = 'p4ssw0rd'
 ENV['SECRET_KEY'] = '7h15-15-50m3-24nd0m-54mp13-k3y'
-ENV['SECRET_ID'] = 'n00b'
 
 # Make some place for testing
 system 'mkdir tmp' unless Dir.exist? 'tmp'


### PR DESCRIPTION
Instead of raising a disruptive error when a secret is not defined, simply ignore it (but let the user know we did).
