### PR TITLE
Add dry run for save and clean operations

### DIFF
--- a/spec/approvals/cli/bulk/clean-dry
+++ b/spec/approvals/cli/bulk/clean-dry
@@ -1,0 +1,8 @@
+user/repo
+user/array-repo
+delete  PASSWORD  
+OK
+delete  SECRET  
+OK
+
+Dry run, nothing happened

--- a/spec/approvals/cli/bulk/help
+++ b/spec/approvals/cli/bulk/help
@@ -4,8 +4,8 @@ Usage:
   secrethub bulk init [CONFIG]
   secrethub bulk show [CONFIG --visible]
   secrethub bulk list [CONFIG]
-  secrethub bulk save [CONFIG --clean]
-  secrethub bulk clean [CONFIG]
+  secrethub bulk save [CONFIG --clean --dry]
+  secrethub bulk clean [CONFIG --dry]
   secrethub bulk (-h|--help)
 
 Commands:
@@ -32,6 +32,9 @@ Options:
   -v, --visible
     Also show secret values
 
+  -d, --dry
+    Dry run
+
   -h --help
     Show this help
 
@@ -44,5 +47,5 @@ Examples:
   secrethub bulk show --visible
   secrethub bulk clean
   secrethub bulk list mysecrets.yml
-  secrethub bulk save mysecrets.yml
+  secrethub bulk save mysecrets.yml --dry
   secrethub bulk save --clean

--- a/spec/approvals/cli/bulk/save-dry
+++ b/spec/approvals/cli/bulk/save-dry
@@ -1,0 +1,19 @@
+user/repo
+save    SECRET  
+OK
+save    PASSWORD  
+OK
+save    SECRET_KEY  
+OK
+user/array-repo
+save    SECRET_KEY  
+OK
+save    SECRET_ID  
+MISSING
+delete  PASSWORD  
+OK
+delete  SECRET  
+OK
+
+Skipped 1 missing secrets
+Dry run, nothing happened

--- a/spec/approvals/cli/bulk/usage
+++ b/spec/approvals/cli/bulk/usage
@@ -2,6 +2,6 @@ Usage:
   secrethub bulk init [CONFIG]
   secrethub bulk show [CONFIG --visible]
   secrethub bulk list [CONFIG]
-  secrethub bulk save [CONFIG --clean]
-  secrethub bulk clean [CONFIG]
+  secrethub bulk save [CONFIG --clean --dry]
+  secrethub bulk clean [CONFIG --dry]
   secrethub bulk (-h|--help)

--- a/spec/secret_hub/commands/bulk_spec.rb
+++ b/spec/secret_hub/commands/bulk_spec.rb
@@ -41,7 +41,7 @@ describe 'bin/secrethub bulk' do
       expect { subject.run %W[bulk show #{config_file}] }.to output_fixture('cli/bulk/show')
     end
 
-    context "--visible" do
+    describe "--visible" do
       it "shows the local configuration file and revealed secrets" do
         expect { subject.run %W[bulk show #{config_file} --visible] }.to output_fixture('cli/bulk/show-visible')
       end      

--- a/spec/secret_hub/commands/bulk_spec.rb
+++ b/spec/secret_hub/commands/bulk_spec.rb
@@ -41,7 +41,7 @@ describe 'bin/secrethub bulk' do
       expect { subject.run %W[bulk show #{config_file}] }.to output_fixture('cli/bulk/show')
     end
 
-    context "with --visible" do
+    context "--visible" do
       it "shows the local configuration file and revealed secrets" do
         expect { subject.run %W[bulk show #{config_file} --visible] }.to output_fixture('cli/bulk/show-visible')
       end      
@@ -60,6 +60,14 @@ describe 'bin/secrethub bulk' do
         expect { subject.run %W[bulk save #{config_file} --clean] }.to output_fixture('cli/bulk/save-clean')
       end
     end
+
+    describe "--dry" do
+      it "shows but does not save anything" do
+        expect_any_instance_of(GitHubClient).not_to receive(:put_secret)
+        expect_any_instance_of(GitHubClient).not_to receive(:delete_secret)
+        expect { subject.run %W[bulk save #{config_file} --clean --dry] }.to output_fixture('cli/bulk/save-dry')
+      end
+    end
   end
 
   describe "clean" do
@@ -69,5 +77,11 @@ describe 'bin/secrethub bulk' do
       expect { subject.run %W[bulk clean #{config_file}] }.to output_fixture('cli/bulk/clean')
     end
 
+    describe "--dry" do
+      it "shows but does not clean anything" do
+        expect_any_instance_of(GitHubClient).not_to receive(:delete_secret)
+        expect { subject.run %W[bulk clean #{config_file} --dry] }.to output_fixture('cli/bulk/clean-dry')
+      end
+    end
   end
 end


### PR DESCRIPTION
Add `--dry` to both `bulk save` and `bulk clean` operations. This will show what will happen without doing anything on any GitHub repo.