### PR TITLE
Add more support for secrets from env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Run secrethub COMMAND --help for command specific help
 $ secrethub repo
 Usage:
   secrethub repo list REPO
-  secrethub repo save REPO KEY VALUE
+  secrethub repo save REPO KEY [VALUE]
   secrethub repo delete REPO KEY
   secrethub repo (-h|--help)
 
@@ -69,7 +69,7 @@ Usage:
 $ secrethub org
 Usage:
   secrethub org list ORG
-  secrethub org save ORG KEY VALUE
+  secrethub org save ORG KEY [VALUE]
   secrethub org delete ORG KEY
   secrethub org (-h|--help)
 

--- a/lib/secret_hub/commands/org.rb
+++ b/lib/secret_hub/commands/org.rb
@@ -4,7 +4,7 @@ module SecretHub
       summary "Manage organization secrets"
       
       usage "secrethub org list ORG"
-      usage "secrethub org save ORG KEY VALUE"
+      usage "secrethub org save ORG KEY [VALUE]"
       usage "secrethub org delete ORG KEY"
       usage "secrethub org (-h|--help)"
 
@@ -14,9 +14,10 @@ module SecretHub
 
       param "ORG", "Name of the organization"
       param "KEY", "The name of the secret"
-      param "VALUE", "The plain text secret value"
+      param "VALUE", "The plain text secret value. If not provided, it is expected to be set as an environment variable"
 
       example "secrethub org list myorg"
+      example "secrethub org save myorg PASSWORD"
       example "secrethub org save myorg PASSWORD s3cr3t"
       example "secrethub org delete myorg PASSWORD"
 
@@ -48,7 +49,12 @@ module SecretHub
       end
 
       def value
-        args['VALUE']
+        result = args['VALUE'] || ENV[key]
+        if result
+          result
+        else
+          raise InvalidInput, "Please provide a value, either in the command line or in the environment variable '#{key}'"
+        end
       end
 
     end

--- a/lib/secret_hub/commands/repo.rb
+++ b/lib/secret_hub/commands/repo.rb
@@ -4,7 +4,7 @@ module SecretHub
       summary "Manage repository secrets"
       
       usage "secrethub repo list REPO"
-      usage "secrethub repo save REPO KEY VALUE"
+      usage "secrethub repo save REPO KEY [VALUE]"
       usage "secrethub repo delete REPO KEY"
       usage "secrethub repo (-h|--help)"
 
@@ -14,9 +14,10 @@ module SecretHub
 
       param "REPO", "Full name of the GitHub repository (user/repo)"
       param "KEY", "The name of the secret"
-      param "VALUE", "The plain text secret value"
+      param "VALUE", "The plain text secret value. If not provided, it is expected to be set as an environment variable"
 
       example "secrethub repo list me/myrepo"
+      example "secrethub repo save me/myrepo PASSWORD"
       example "secrethub repo save me/myrepo PASSWORD s3cr3t"
       example "secrethub repo delete me/myrepo PASSWORD"
 
@@ -48,9 +49,13 @@ module SecretHub
       end
 
       def value
-        args['VALUE']
+        result = args['VALUE'] || ENV[key]
+        if result
+          result
+        else
+          raise InvalidInput, "Please provide a value, either in the command line or in the environment variable '#{key}'"
+        end
       end
-
     end
   end
 end

--- a/lib/secret_hub/exceptions.rb
+++ b/lib/secret_hub/exceptions.rb
@@ -1,6 +1,7 @@
 module SecretHub
   SecretHubError = Class.new StandardError
   ConfigurationError = Class.new SecretHubError
+  InvalidInput = Class.new SecretHubError
   
   class APIError < SecretHubError
     attr_reader :response

--- a/spec/approvals/cli/org/help
+++ b/spec/approvals/cli/org/help
@@ -2,7 +2,7 @@ Manage organization secrets
 
 Usage:
   secrethub org list ORG
-  secrethub org save ORG KEY VALUE
+  secrethub org save ORG KEY [VALUE]
   secrethub org delete ORG KEY
   secrethub org (-h|--help)
 
@@ -29,9 +29,11 @@ Parameters:
     The name of the secret
 
   VALUE
-    The plain text secret value
+    The plain text secret value. If not provided, it is expected to be set as an
+    environment variable
 
 Examples:
   secrethub org list myorg
+  secrethub org save myorg PASSWORD
   secrethub org save myorg PASSWORD s3cr3t
   secrethub org delete myorg PASSWORD

--- a/spec/approvals/cli/org/usage
+++ b/spec/approvals/cli/org/usage
@@ -1,5 +1,5 @@
 Usage:
   secrethub org list ORG
-  secrethub org save ORG KEY VALUE
+  secrethub org save ORG KEY [VALUE]
   secrethub org delete ORG KEY
   secrethub org (-h|--help)

--- a/spec/approvals/cli/repo/help
+++ b/spec/approvals/cli/repo/help
@@ -2,7 +2,7 @@ Manage repository secrets
 
 Usage:
   secrethub repo list REPO
-  secrethub repo save REPO KEY VALUE
+  secrethub repo save REPO KEY [VALUE]
   secrethub repo delete REPO KEY
   secrethub repo (-h|--help)
 
@@ -28,9 +28,11 @@ Parameters:
     The name of the secret
 
   VALUE
-    The plain text secret value
+    The plain text secret value. If not provided, it is expected to be set as an
+    environment variable
 
 Examples:
   secrethub repo list me/myrepo
+  secrethub repo save me/myrepo PASSWORD
   secrethub repo save me/myrepo PASSWORD s3cr3t
   secrethub repo delete me/myrepo PASSWORD

--- a/spec/approvals/cli/repo/usage
+++ b/spec/approvals/cli/repo/usage
@@ -1,5 +1,5 @@
 Usage:
   secrethub repo list REPO
-  secrethub repo save REPO KEY VALUE
+  secrethub repo save REPO KEY [VALUE]
   secrethub repo delete REPO KEY
   secrethub repo (-h|--help)

--- a/spec/secret_hub/commands/org_spec.rb
+++ b/spec/secret_hub/commands/org_spec.rb
@@ -15,19 +15,36 @@ describe 'bin/secrethub org' do
     end
   end
 
-  describe "list" do
+  describe "list ORG" do
     it "shows list of secrets" do
       expect { subject.run %w[org list matz] }.to output_fixture('cli/org/list/ok')
     end
   end
 
-  describe "save" do
+  describe "save ORG KEY VALUE" do
     it "saves the secret" do
       expect { subject.run %w[org save matz PASSWORD p4ssw0rd] }.to output_fixture('cli/org/save/ok')
     end
   end
 
-  describe "delete" do
+  describe "save ORG KEY" do
+    context "when the value exists in the environemnt" do
+      before { ENV['PASSWORD'] = 's3cr3tz' }
+      after { ENV['PASSWORD'] = nil }
+      
+      it "saves the secret" do
+        expect { subject.run %w[org save matz PASSWORD] }.to output_fixture('cli/org/save/ok')
+      end
+    end
+
+    context "when the value does not exist in the environemnt" do
+      it "raises InvalidInput" do
+        expect { subject.run %w[org save matz PASSWORD] }.to raise_error(InvalidInput)
+      end
+    end
+  end
+
+  describe "delete ORG KEY" do
     it "deletes the secret" do
       expect { subject.run %w[org delete matz PASSWORD] }.to output_fixture('cli/org/delete/ok')
     end

--- a/spec/secret_hub/commands/repo_spec.rb
+++ b/spec/secret_hub/commands/repo_spec.rb
@@ -15,19 +15,36 @@ describe 'bin/secrethub repo' do
     end
   end
 
-  describe "list" do
+  describe "list REPO" do
     it "shows list of secrets" do
       expect { subject.run %w[repo list matz/ruby] }.to output_fixture('cli/repo/list/ok')
     end
   end
 
-  describe "save" do
+  describe "save REPO KEY" do
+    context "when the value exists in the environemnt" do
+      before { ENV['PASSWORD'] = 's3cr3tz' }
+      after { ENV['PASSWORD'] = nil }
+      
+      it "saves the secret" do
+        expect { subject.run %w[repo save matz/ruby PASSWORD] }.to output_fixture('cli/repo/save/ok')
+      end
+    end
+
+    context "when the value does not exist in the environemnt" do
+      it "raises InvalidInput" do
+        expect { subject.run %w[repo save matz/ruby PASSWORD] }.to raise_error(InvalidInput)
+      end
+    end
+  end
+
+  describe "save REPO KEY VALUE" do
     it "saves the secret" do
       expect { subject.run %w[repo save matz/ruby PASSWORD p4ssw0rd] }.to output_fixture('cli/repo/save/ok')
     end
   end
 
-  describe "delete" do
+  describe "delete REPO KEY" do
     it "deletes the secret" do
       expect { subject.run %w[repo delete matz/ruby PASSWORD] }.to output_fixture('cli/repo/delete/ok')
     end


### PR DESCRIPTION
This modifies the `secrethub repo save` and `secrethub org save` so that the secret value is optional. If used like this, it is expected to be available in the environment.

```diff
- secrethub org save ORG KEY VALUE
+ secrethub org save ORG KEY [VALUE]

- secrethub repo save REPO KEY VALUE
+ secrethub repo save REPO KEY [VALUE]
```