### PR TITLE
Updates for Ruby 3.3 and Rack 3

### DIFF
--- a/.github/workflows/docker-latest.yml
+++ b/.github/workflows/docker-latest.yml
@@ -1,0 +1,28 @@
+name: Docker build (version + latest)
+on:
+  push: { tags: 'v[0-9]+.[0-9]+.[0-9]+' }
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Extract tag
+        run: echo "TAG=${GITHUB_REF#refs/*/v}" >> $GITHUB_ENV
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: dannyben/secrethub,dannyben/secrethub:${{ env.TAG }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
-      matrix: { ruby: ['3.0', '3.1', '3.2', head] }
+      matrix: { ruby: ['3.0', '3.1', '3.2', '3.3'] }
 
     steps:
     - name: Check out code

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM dannyben/alpine-ruby
+FROM dannyben/alpine-ruby:3.2.2
 
 RUN apk add --no-cache libsodium-dev
 RUN gem install secret_hub --version 0.2.1

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'byebug'
+gem 'debug'
 gem 'lp'
 gem 'pretty_trace'
 gem 'puma', require: false

--- a/Runfile
+++ b/Runfile
@@ -1,4 +1,4 @@
-require "byebug"
+require 'debug'
 require 'secret_hub'
 require 'secret_hub/version'
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   secrethub:
     build: .

--- a/lib/secret_hub.rb
+++ b/lib/secret_hub.rb
@@ -2,5 +2,3 @@ require 'secret_hub/version'
 require 'secret_hub/exceptions'
 require 'secret_hub/github_client'
 require 'secret_hub/config'
-
-require 'byebug' if ENV['BYEBUG']

--- a/secret_hub.gemspec
+++ b/secret_hub.gemspec
@@ -15,12 +15,17 @@ Gem::Specification.new do |s|
   s.license     = 'MIT'
   s.required_ruby_version = '>= 3.0'
 
-  s.add_runtime_dependency 'colsole', '>= 0.8.1', '< 2'
-  s.add_runtime_dependency 'httparty', '~> 0.21'
-  s.add_runtime_dependency 'lp', '~> 0.2'
-  s.add_runtime_dependency 'mister_bin', '~> 0.7.3'
-  s.add_runtime_dependency 'rbnacl', '~> 7.1'
-  s.add_runtime_dependency 'string-obfuscator', '~> 0.1'
+  s.add_dependency 'colsole', '>= 0.8.1', '< 2'
+  s.add_dependency 'httparty', '~> 0.21'
+  s.add_dependency 'lp', '~> 0.2'
+  s.add_dependency 'mister_bin', '~> 0.7.3'
+  s.add_dependency 'rackup', '~> 2.1'
+  s.add_dependency 'rbnacl', '~> 7.1'
+  s.add_dependency 'string-obfuscator', '~> 0.1'
+
+  # REMOVE ME
+  s.add_dependency 'bigdecimal', '>= 0'  # to address ruby warning by multi_xml
+  s.add_dependency 'csv', '>= 0'         # to address ruby warning by httparty
 
   s.metadata['rubygems_mfa_required'] = 'true'
 end

--- a/spec/mock_api/server.rb
+++ b/spec/mock_api/server.rb
@@ -1,5 +1,5 @@
 require 'sinatra'
-require 'byebug'
+require 'debug'
 require 'yaml'
 require_relative '../fake_public_key'
 


### PR DESCRIPTION
- Add automated docker build GitHub Action
- Lock docker image to Ruby 3.2.2 for consistency
- Replace `byebug` gem with `debug` and remove conditional loading from non-development code
- Normalize `docker-compose.yml`
- Add `rackup` gem dependency
- Add `bigdecimal` and `csv` gem dependencies to clear Ruby 3.3 warnings
- Add Ruby 3.3 to test matrix